### PR TITLE
Add tmux support.

### DIFF
--- a/etc/osc52.el
+++ b/etc/osc52.el
@@ -97,7 +97,7 @@ causes tmux to pass the wrapped OSC 52 sequence along to the host terminal."
                                            (base64-encode-string string))
                  "\07\e\\"))
       (message "Selection too long to send to terminal %d" b64-length)
-      (set-for 2))))
+      (sit-for 2))))
 
 (defun osc52-set-cut-function ()
   "Initialize the `interprogram-cut-function' based on the value of

--- a/etc/osc52.el
+++ b/etc/osc52.el
@@ -10,12 +10,8 @@
 ;; It works in hterm, xterm, and other terminal emulators which support the
 ;; sequence.
 ;;
-;; It also works under screen, via the `osc52-select-text-dcs' defined below, as
-;; long as the outer terminal supports OSC 52.
-;;
-;; It doesn't work under tmux.  Tmux consumes the OSC 52 sequence and doesn't
-;; use the DSC sequence as a pass-through to the host terminal.  Please feel
-;; free to submit patches.
+;; As long as the outer terminal supports OSC 52, this will also works under
+;; screen via `osc52-select-text-dcs', and tmux via `osc52-select-text-tmux'.
 ;;
 
 (defcustom osc52-max-sequence 100000
@@ -80,11 +76,34 @@ hitting screen's max DCS length."
         (message "Selection too long to send to terminal %d" b64-length)
         (sit-for 2))))
 
+(defun osc52-select-text-tmux (string &optional replace yank-handler)
+  "Copy STRING to the system clipboard using the OSC 52 escape sequence, for
+tmux users.
+
+Set `interprogram-cut-function' to this when using the tmux program, and your
+system clipboard will be updated whenever you copy a region of text in emacs.
+
+If the resulting OSC 52 sequence would be longer than
+`osc52-max-sequence', then the STRING is not sent to the system
+clipboard.
+
+This function wraps the OSC 52 in a Device Control String sequence.  This
+causes tmux to pass the wrapped OSC 52 sequence along to the host terminal."
+  (let ((b64-length (+ (* (length string) 3) 2)))
+    (if (<= b64-length osc52-max-sequence)
+        (send-string-to-terminal
+         (concat "\ePtmux;\e\e]52;c;"
+                 (replace-regexp-in-string "\n" ""
+                                           (base64-encode-string string))
+                 "\07\e\\"))
+      (message "Selection too long to send to terminal %d" b64-length)
+      (set-for 2))))
+
 (defun osc52-set-cut-function ()
   "Initialize the `interprogram-cut-function' based on the value of
 `window-system' and the TERM environment variable."
   (if (not window-system)
       (setq interprogram-cut-function
-            (if (string-match "^screen" (getenv "TERM"))
-                'osc52-select-text-dcs
-                'osc52-select-text))))
+            (cond ((not (null (getenv "STY"))) 'osc52-select-text-dcs)
+                  ((not (null (getenv "TMUX"))) 'osc52-select-text-tmux)
+                  (t 'osc52-select-text)))))


### PR DESCRIPTION
I followed along [this post](http://comments.gmane.org/gmane.comp.terminal-emulators.tmux.user/6024) and it seems that modern versions of `tmux` have a special pass-through sequence that lets you get to the outer terminal. Chunking doesn't appear to be required.

Lightly tested, but seems to work. 